### PR TITLE
Remove ExponentialBackoff from rchttp client

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ import "github.com/ONSdigital/go-ns/rchttp"
 
 func main() {
     rcClient := &rchttp.Client{
-        MaxRetries:         10,              // The maximum number of retries you wish to wait for
-        ExponentialBackoff: true,            // Set to false if you do not want exponential backoff
+        MaxRetries:         10,              // The maximum number of retries you wish to wait for, the retry method implements exponential backoff
         RetryTime:          1 * time.Second, // The time between the first set of retries
 
         HTTPClient: &http.Client{            // Create your own http client with configured timeouts

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ rchttp should have a familiar feel to it when it is used - with an example given
 below:
 
 ```go
-import "github.com/ONSdigital/go-ns/rchttp"
+import rchttp "github.com/ONSdigital/dp-rchttp"
 
 func httpHandlerFunc(w http.ResponseWriter, req *http.Request) {
     client := rchttp.NewClient()
@@ -36,15 +36,15 @@ timeouts or do not wish to use exponential backoff. The following example shows
 how to configure your own rchttp client:
 
 ```go
-import "github.com/ONSdigital/go-ns/rchttp"
+import rchttp "github.com/ONSdigital/dp-rchttp"
 
 func main() {
     rcClient := &rchttp.Client{
         // MaxRetries is the maximum number of retries you wish to
         // wait for, the retry method implements exponential backoff
         MaxRetries:         10,
-        // RetryTime is the time between the first set of retries
-        RetryTime:          1 * time.Second, 
+        // RetryTime is the gap before (any) first retry (increases for second retry, and so on)
+        RetryTime:          1 * time.Second,
         // Create your own http client with configured timeouts
         HTTPClient: &http.Client{
             Timeout: 10 * time.Second,

--- a/README.md
+++ b/README.md
@@ -40,10 +40,13 @@ import "github.com/ONSdigital/go-ns/rchttp"
 
 func main() {
     rcClient := &rchttp.Client{
-        MaxRetries:         10,              // The maximum number of retries you wish to wait for, the retry method implements exponential backoff
-        RetryTime:          1 * time.Second, // The time between the first set of retries
-
-        HTTPClient: &http.Client{            // Create your own http client with configured timeouts
+        // MaxRetries is the maximum number of retries you wish to
+        // wait for, the retry method implements exponential backoff
+        MaxRetries:         10,
+        // RetryTime is the time between the first set of retries
+        RetryTime:          1 * time.Second, 
+        // Create your own http client with configured timeouts
+        HTTPClient: &http.Client{
             Timeout: 10 * time.Second,
             Transport: &http.Transport{
                 DialContext: (&net.Dialer{

--- a/client.go
+++ b/client.go
@@ -190,9 +190,11 @@ func (c *Client) PostForm(ctx context.Context, uri string, data url.Values) (*ht
 	return c.Post(ctx, uri, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
 }
 
+type Doer = func(context.Context, *http.Client, *http.Request) (*http.Response, error)
+
 func (c *Client) backoff(
 	ctx context.Context,
-	doer func(context.Context, *http.Client, *http.Request) (*http.Response, error),
+	doer Doer,
 	client *http.Client,
 	req *http.Request,
 ) (resp *http.Response, err error) {

--- a/client.go
+++ b/client.go
@@ -18,20 +18,18 @@ import (
 )
 
 // Client is an extension of the net/http client with ability to add
-// timeouts, exponential backoff and context-based cancellation
+// timeouts, exponential backoff and context-based cancellation.
 type Client struct {
-	MaxRetries         int
-	ExponentialBackoff bool
-	RetryTime          time.Duration
-	HTTPClient         *http.Client
+	MaxRetries int
+	RetryTime  time.Duration
+	HTTPClient *http.Client
 }
 
 // DefaultClient is a go-ns specific http client with sensible timeouts,
-// exponential backoff, and a contextual dialer
+// exponential backoff, and a contextual dialer.
 var DefaultClient = &Client{
-	MaxRetries:         10,
-	ExponentialBackoff: true,
-	RetryTime:          20 * time.Millisecond,
+	MaxRetries: 10,
+	RetryTime:  20 * time.Millisecond,
 
 	HTTPClient: &http.Client{
 		Timeout: 10 * time.Second,
@@ -46,7 +44,7 @@ var DefaultClient = &Client{
 	},
 }
 
-// Clienter provides an interface for methods on an HTTP Client
+// Clienter provides an interface for methods on an HTTP Client.
 type Clienter interface {
 	SetTimeout(timeout time.Duration)
 	SetMaxRetries(int)
@@ -61,13 +59,13 @@ type Clienter interface {
 	Do(ctx context.Context, req *http.Request) (*http.Response, error)
 }
 
-// NewClient returns a copy of DefaultClient
+// NewClient returns a copy of DefaultClient.
 func NewClient() Clienter {
 	newClient := *DefaultClient
 	return &newClient
 }
 
-// ClientWithTimeout facilitates creating a client and setting request timeout
+// ClientWithTimeout facilitates creating a client and setting request timeout.
 func ClientWithTimeout(c Clienter, timeout time.Duration) Clienter {
 	if c == nil {
 		c = NewClient()
@@ -76,19 +74,22 @@ func ClientWithTimeout(c Clienter, timeout time.Duration) Clienter {
 	return c
 }
 
-// SetTimeout sets HTTP request timeout
+// SetTimeout sets HTTP request timeout.
 func (c *Client) SetTimeout(timeout time.Duration) {
 	c.HTTPClient.Timeout = timeout
 }
 
+// GetMaxRetries gets the HTTP request maximum number of retries.
 func (c *Client) GetMaxRetries() int {
 	return c.MaxRetries
 }
+
+// SetMaxRetries sets HTTP request maximum number of retries.
 func (c *Client) SetMaxRetries(maxRetries int) {
 	c.MaxRetries = maxRetries
 }
 
-// Do calls ctxhttp.Do with the addition of exponential backoff
+// Do calls ctxhttp.Do with the addition of retries with exponential backoff
 func (c *Client) Do(ctx context.Context, req *http.Request) (*http.Response, error) {
 
 	// TODO: Remove this once user token (Florence token) is propegated throughout apps
@@ -126,13 +127,15 @@ func (c *Client) Do(ctx context.Context, req *http.Request) (*http.Response, err
 
 	resp, err := doer(ctx, c.HTTPClient, req)
 	if err != nil {
-		if c.ExponentialBackoff {
+
+		if c.MaxRetries > 0 {
 			return c.backoff(ctx, doer, err, c.HTTPClient, req)
 		}
-		return nil, err
+
+		return resp, err
 	}
 
-	if c.ExponentialBackoff {
+	if c.MaxRetries > 0 {
 		if resp.StatusCode >= http.StatusInternalServerError {
 			return c.backoff(ctx, doer, err, c.HTTPClient, req)
 		}
@@ -145,7 +148,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request) (*http.Response, err
 	return resp, err
 }
 
-// Get calls Do with a GET
+// Get calls Do with a GET.
 func (c *Client) Get(ctx context.Context, url string) (*http.Response, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -155,7 +158,7 @@ func (c *Client) Get(ctx context.Context, url string) (*http.Response, error) {
 	return c.Do(ctx, req)
 }
 
-// Head calls Do with a HEAD
+// Head calls Do with a HEAD.
 func (c *Client) Head(ctx context.Context, url string) (*http.Response, error) {
 	req, err := http.NewRequest("HEAD", url, nil)
 	if err != nil {
@@ -165,7 +168,7 @@ func (c *Client) Head(ctx context.Context, url string) (*http.Response, error) {
 	return c.Do(ctx, req)
 }
 
-// Post calls Do with a POST and the appropriate content-type and body
+// Post calls Do with a POST and the appropriate content-type and body.
 func (c *Client) Post(ctx context.Context, url string, contentType string, body io.Reader) (*http.Response, error) {
 	req, err := http.NewRequest("POST", url, body)
 	if err != nil {
@@ -176,7 +179,7 @@ func (c *Client) Post(ctx context.Context, url string, contentType string, body 
 	return c.Do(ctx, req)
 }
 
-// Put calls Do with a PUT and the appropriate content-type and body
+// Put calls Do with a PUT and the appropriate content-type and body.
 func (c *Client) Put(ctx context.Context, url string, contentType string, body io.Reader) (*http.Response, error) {
 	req, err := http.NewRequest("PUT", url, body)
 	if err != nil {
@@ -187,23 +190,21 @@ func (c *Client) Put(ctx context.Context, url string, contentType string, body i
 	return c.Do(ctx, req)
 }
 
-// PostForm calls Post with the appropriate form content-type
+// PostForm calls Post with the appropriate form content-type.
 func (c *Client) PostForm(ctx context.Context, uri string, data url.Values) (*http.Response, error) {
 	return c.Post(ctx, uri, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
 }
 
 func (c *Client) backoff(ctx context.Context, doer func(context.Context, *http.Client, *http.Request) (*http.Response, error), retryErr error, client *http.Client, req *http.Request) (resp *http.Response, err error) {
-	if c.GetMaxRetries() < 1 {
-		return nil, retryErr
-	}
-	for attempt := 1; attempt <= c.GetMaxRetries(); attempt++ {
+
+	for retries := 1; retries <= c.GetMaxRetries(); retries++ {
 		// ensure that the context is not cancelled before iterating
 		if ctx.Err() != nil {
 			err = ctx.Err()
 			return
 		}
 
-		time.Sleep(getSleepTime(attempt, c.RetryTime))
+		time.Sleep(getSleepTime(retries, c.RetryTime))
 
 		resp, err = doer(ctx, client, req)
 		// prioritise any context cancellation
@@ -221,7 +222,7 @@ func (c *Client) backoff(ctx context.Context, doer func(context.Context, *http.C
 // getSleepTime will return a sleep time based on the attempt and initial retry time.
 // It uses the algorithm 2^n where n is the attempt number (double the previous) and
 // a randomization factor of between 0-5ms so that the server isn't being hit constantly
-// at the same time by many clients
+// at the same time by many clients.
 func getSleepTime(attempt int, retryTime time.Duration) time.Duration {
 	n := (math.Pow(2, float64(attempt)))
 	rand.Seed(time.Now().Unix())

--- a/rchttptest/server.go
+++ b/rchttptest/server.go
@@ -37,13 +37,15 @@ type RequestTester struct {
 	DelayOnCall   int `json:"delay_on_call"`
 }
 
-func NewTestServer() *TestServer {
+func NewTestServer(statusCode int) *TestServer {
 	callCount := 0
 	var mu sync.Mutex
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		callCount++
 		mu.Unlock()
+
+		w.WriteHeader(statusCode)
 		contentType := r.Header.Get(ContentTypeHeader)
 		b := GetBody(r.Body)
 		headers := make(map[string][]string)

--- a/rchttptest/server.go
+++ b/rchttptest/server.go
@@ -19,8 +19,10 @@ const (
 )
 
 type TestServer struct {
-	Server *httptest.Server
-	URL    string
+	Server    *httptest.Server
+	URL       string
+	CallCount int
+	Mutex     sync.Mutex
 }
 
 type Responder struct {
@@ -38,12 +40,13 @@ type RequestTester struct {
 }
 
 func NewTestServer(statusCode int) *TestServer {
-	callCount := 0
-	var mu sync.Mutex
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		mu.Lock()
-		callCount++
-		mu.Unlock()
+	ts := &TestServer{
+		CallCount: 0,
+		Mutex:     sync.Mutex{},
+	}
+
+	hts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts.GetCalls(1)
 
 		w.WriteHeader(statusCode)
 		contentType := r.Header.Get(ContentTypeHeader)
@@ -52,14 +55,12 @@ func NewTestServer(statusCode int) *TestServer {
 		for h, v := range r.Header {
 			headers[h] = v
 		}
-		mu.Lock()
 		jsonResponse, err := json.Marshal(Responder{
 			Method:    r.Method,
-			CallCount: callCount,
+			CallCount: ts.GetCalls(0),
 			Body:      string(b),
 			Headers:   headers,
 		})
-		mu.Unlock()
 		if err != nil {
 			convertErrorToOutput(w, contentType, err)
 			return
@@ -78,9 +79,7 @@ func NewTestServer(statusCode int) *TestServer {
 					convertErrorToOutput(w, contentType, err)
 					return
 				}
-				mu.Lock()
-				callCountNow := callCount
-				mu.Unlock()
+				callCountNow := ts.GetCalls(0)
 				if reqTest.DelayOnCall == callCountNow {
 					time.Sleep(delayDuration)
 				}
@@ -89,14 +88,22 @@ func NewTestServer(statusCode int) *TestServer {
 
 		fmt.Fprint(w, string(jsonResponse))
 	}))
-	return &TestServer{
-		Server: ts,
-		URL:    ts.URL,
-	}
+
+	ts.Server = hts
+	ts.URL = hts.URL
+
+	return ts
 }
 
 func (ts *TestServer) Close() {
 	ts.Server.Close()
+}
+
+func (ts *TestServer) GetCalls(delta int) int {
+	ts.Mutex.Lock()
+	ts.CallCount += delta
+	defer ts.Mutex.Unlock()
+	return ts.CallCount
 }
 
 func convertErrorToOutput(w io.Writer, contentType string, err error) {


### PR DESCRIPTION
### What

There is only one type of retry method and that is exponential backoff.
Now the library will only retry with exponential backoff if maxRetries
is set to more than 0 (previously this would need to be set to at least 1,
otherwise the http response would result in a nil value with no error for
a 500 response from client.

* Removed ExponentialBackoff field in rchttp client struct
* Updated Do logic for calling backoff function - only gets called when maxRetries is more than 0
* Tests updated to cover when there are no retries

### How to review

* check logic
* run tests

### Who can review

Anyone