### PR TITLE
rchttp client contains new variable to stop retries on certain paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Mac OSX
+*.DS_Store
+
+# ides
+.idea/
+.vagrant
+.vscode
+*.iml
+
+*.swp

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ func main() {
         MaxRetries:         10,
         // RetryTime is the gap before (any) first retry (increases for second retry, and so on)
         RetryTime:          1 * time.Second,
+        // PathsWithNoRetries is a list of all paths that you do not wish to retry call on failure,
+        // the path should be set to true (default client has empty map)
+        PathsWithNoRetries: map[string]bool{
+			"/health": true,
+		},
         // Create your own http client with configured timeouts
         HTTPClient: &http.Client{
             Timeout: 10 * time.Second,

--- a/client.go
+++ b/client.go
@@ -51,7 +51,7 @@ type Clienter interface {
 	SetMaxRetries(int)
 	GetMaxRetries() int
 	SetPathsWithNoRetries([]string)
-	GetPathsWithNoRetries() map[string]bool
+	GetPathsWithNoRetries() []string
 
 	Get(ctx context.Context, url string) (*http.Response, error)
 	Head(ctx context.Context, url string) (*http.Response, error)
@@ -103,8 +103,11 @@ func (c *Client) SetMaxRetries(maxRetries int) {
 }
 
 // GetPathsWithNoRetries sets a list of paths that will HTTP request will not retry on error.
-func (c *Client) GetPathsWithNoRetries() map[string]bool {
-	return c.PathsWithNoRetries
+func (c *Client) GetPathsWithNoRetries() (paths []string) {
+	for path, _ := range c.PathsWithNoRetries {
+		paths = append(paths, path)
+	}
+	return paths
 }
 
 // SetPathsWithNoRetries sets a list of paths that will HTTP request will not retry on error.

--- a/client.go
+++ b/client.go
@@ -102,7 +102,7 @@ func (c *Client) SetMaxRetries(maxRetries int) {
 	c.MaxRetries = maxRetries
 }
 
-// GetPathsWithNoRetries sets a list of paths that will HTTP request will not retry on error.
+// GetPathsWithNoRetries gets a list of paths that will HTTP request will not retry on error.
 func (c *Client) GetPathsWithNoRetries() (paths []string) {
 	for path, _ := range c.PathsWithNoRetries {
 		paths = append(paths, path)

--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -358,19 +359,17 @@ func TestSetPathsWithNoRetries(t *testing.T) {
 	Convey("Successfully create map of paths when SetPathsWithNoRetries is called", t, func() {
 		client.SetPathsWithNoRetries([]string{"/health", "/healthcheck"})
 		paths := client.GetPathsWithNoRetries()
+		sort.Strings(paths) // cannot guarentee order of paths
 		So(len(paths), ShouldEqual, 2)
-		So(paths["/health"], ShouldEqual, true)
-		So(paths["/healthcheck"], ShouldEqual, true)
-		So(paths["/healthy"], ShouldEqual, false)
+		So(paths[1], ShouldEqual, "/health")
+		So(paths[0], ShouldEqual, "/healthcheck")
 	})
 
 	Convey("Successfully update client with map of paths with ClientWithListOfNonRetriablePaths", t, func() {
 		ClientWithListOfNonRetriablePaths(client, []string{"/test"})
 		paths := client.GetPathsWithNoRetries()
 		So(len(paths), ShouldEqual, 1)
-		So(paths["/test"], ShouldEqual, true)
-		So(paths["/health"], ShouldEqual, false)
-		So(paths["/healthcheck"], ShouldEqual, false)
+		So(paths[0], ShouldEqual, "/test")
 	})
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -361,8 +361,8 @@ func TestSetPathsWithNoRetries(t *testing.T) {
 		paths := client.GetPathsWithNoRetries()
 		sort.Strings(paths) // cannot guarentee order of paths
 		So(len(paths), ShouldEqual, 2)
-		So(paths[1], ShouldEqual, "/health")
-		So(paths[0], ShouldEqual, "/healthcheck")
+		So(paths[0], ShouldEqual, "/health")
+		So(paths[1], ShouldEqual, "/healthcheck")
 	})
 
 	Convey("Successfully update client with map of paths with ClientWithListOfNonRetriablePaths", t, func() {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/ONSdigital/dp-rchttp
+
+go 1.12
+
+require (
+	github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58
+	github.com/smartystreets/goconvey v1.6.4
+	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58 h1:XHnzoC7TxueLAfkBpblPiwaIxjngGv1VNVZhvE4jY6w=
+github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
+github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8oukgn+8D8WgaCaRMchF8=
+golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/mock_client.go
+++ b/mock_client.go
@@ -13,20 +13,18 @@ import (
 )
 
 var (
-	lockClienterMockDo            sync.RWMutex
-	lockClienterMockGet           sync.RWMutex
-	lockClienterMockGetMaxRetries sync.RWMutex
-	lockClienterMockHead          sync.RWMutex
-	lockClienterMockPost          sync.RWMutex
-	lockClienterMockPostForm      sync.RWMutex
-	lockClienterMockPut           sync.RWMutex
-	lockClienterMockSetMaxRetries sync.RWMutex
-	lockClienterMockSetTimeout    sync.RWMutex
+	lockClienterMockDo                    sync.RWMutex
+	lockClienterMockGet                   sync.RWMutex
+	lockClienterMockGetMaxRetries         sync.RWMutex
+	lockClienterMockGetPathsWithNoRetries sync.RWMutex
+	lockClienterMockHead                  sync.RWMutex
+	lockClienterMockPost                  sync.RWMutex
+	lockClienterMockPostForm              sync.RWMutex
+	lockClienterMockPut                   sync.RWMutex
+	lockClienterMockSetMaxRetries         sync.RWMutex
+	lockClienterMockSetPathsWithNoRetries sync.RWMutex
+	lockClienterMockSetTimeout            sync.RWMutex
 )
-
-// Ensure, that ClienterMock does implement Clienter.
-// If this is not the case, regenerate this file with moq.
-var _ Clienter = &ClienterMock{}
 
 // ClienterMock is a mock implementation of Clienter.
 //
@@ -35,36 +33,42 @@ var _ Clienter = &ClienterMock{}
 //         // make and configure a mocked Clienter
 //         mockedClienter := &ClienterMock{
 //             DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
-// 	               panic("mock out the Do method")
+// 	               panic("TODO: mock out the Do method")
 //             },
 //             GetFunc: func(ctx context.Context, url string) (*http.Response, error) {
-// 	               panic("mock out the Get method")
+// 	               panic("TODO: mock out the Get method")
 //             },
 //             GetMaxRetriesFunc: func() int {
-// 	               panic("mock out the GetMaxRetries method")
+// 	               panic("TODO: mock out the GetMaxRetries method")
+//             },
+//             GetPathsWithNoRetriesFunc: func() map[string]bool {
+// 	               panic("TODO: mock out the GetPathsWithNoRetries method")
 //             },
 //             HeadFunc: func(ctx context.Context, url string) (*http.Response, error) {
-// 	               panic("mock out the Head method")
+// 	               panic("TODO: mock out the Head method")
 //             },
 //             PostFunc: func(ctx context.Context, url string, contentType string, body io.Reader) (*http.Response, error) {
-// 	               panic("mock out the Post method")
+// 	               panic("TODO: mock out the Post method")
 //             },
 //             PostFormFunc: func(ctx context.Context, uri string, data url.Values) (*http.Response, error) {
-// 	               panic("mock out the PostForm method")
+// 	               panic("TODO: mock out the PostForm method")
 //             },
 //             PutFunc: func(ctx context.Context, url string, contentType string, body io.Reader) (*http.Response, error) {
-// 	               panic("mock out the Put method")
+// 	               panic("TODO: mock out the Put method")
 //             },
 //             SetMaxRetriesFunc: func(in1 int)  {
-// 	               panic("mock out the SetMaxRetries method")
+// 	               panic("TODO: mock out the SetMaxRetries method")
+//             },
+//             SetPathsWithNoRetriesFunc: func(in1 []string)  {
+// 	               panic("TODO: mock out the SetPathsWithNoRetries method")
 //             },
 //             SetTimeoutFunc: func(timeout time.Duration)  {
-// 	               panic("mock out the SetTimeout method")
+// 	               panic("TODO: mock out the SetTimeout method")
 //             },
 //         }
 //
-//         // use mockedClienter in code that requires Clienter
-//         // and then make assertions.
+//         // TODO: use mockedClienter in code that requires Clienter
+//         //       and then make assertions.
 //
 //     }
 type ClienterMock struct {
@@ -76,6 +80,9 @@ type ClienterMock struct {
 
 	// GetMaxRetriesFunc mocks the GetMaxRetries method.
 	GetMaxRetriesFunc func() int
+
+	// GetPathsWithNoRetriesFunc mocks the GetPathsWithNoRetries method.
+	GetPathsWithNoRetriesFunc func() map[string]bool
 
 	// HeadFunc mocks the Head method.
 	HeadFunc func(ctx context.Context, url string) (*http.Response, error)
@@ -91,6 +98,9 @@ type ClienterMock struct {
 
 	// SetMaxRetriesFunc mocks the SetMaxRetries method.
 	SetMaxRetriesFunc func(in1 int)
+
+	// SetPathsWithNoRetriesFunc mocks the SetPathsWithNoRetries method.
+	SetPathsWithNoRetriesFunc func(in1 []string)
 
 	// SetTimeoutFunc mocks the SetTimeout method.
 	SetTimeoutFunc func(timeout time.Duration)
@@ -113,6 +123,9 @@ type ClienterMock struct {
 		}
 		// GetMaxRetries holds details about calls to the GetMaxRetries method.
 		GetMaxRetries []struct {
+		}
+		// GetPathsWithNoRetries holds details about calls to the GetPathsWithNoRetries method.
+		GetPathsWithNoRetries []struct {
 		}
 		// Head holds details about calls to the Head method.
 		Head []struct {
@@ -156,6 +169,11 @@ type ClienterMock struct {
 		SetMaxRetries []struct {
 			// In1 is the in1 argument value.
 			In1 int
+		}
+		// SetPathsWithNoRetries holds details about calls to the SetPathsWithNoRetries method.
+		SetPathsWithNoRetries []struct {
+			// In1 is the in1 argument value.
+			In1 []string
 		}
 		// SetTimeout holds details about calls to the SetTimeout method.
 		SetTimeout []struct {
@@ -258,6 +276,32 @@ func (mock *ClienterMock) GetMaxRetriesCalls() []struct {
 	lockClienterMockGetMaxRetries.RLock()
 	calls = mock.calls.GetMaxRetries
 	lockClienterMockGetMaxRetries.RUnlock()
+	return calls
+}
+
+// GetPathsWithNoRetries calls GetPathsWithNoRetriesFunc.
+func (mock *ClienterMock) GetPathsWithNoRetries() map[string]bool {
+	if mock.GetPathsWithNoRetriesFunc == nil {
+		panic("ClienterMock.GetPathsWithNoRetriesFunc: method is nil but Clienter.GetPathsWithNoRetries was just called")
+	}
+	callInfo := struct {
+	}{}
+	lockClienterMockGetPathsWithNoRetries.Lock()
+	mock.calls.GetPathsWithNoRetries = append(mock.calls.GetPathsWithNoRetries, callInfo)
+	lockClienterMockGetPathsWithNoRetries.Unlock()
+	return mock.GetPathsWithNoRetriesFunc()
+}
+
+// GetPathsWithNoRetriesCalls gets all the calls that were made to GetPathsWithNoRetries.
+// Check the length with:
+//     len(mockedClienter.GetPathsWithNoRetriesCalls())
+func (mock *ClienterMock) GetPathsWithNoRetriesCalls() []struct {
+} {
+	var calls []struct {
+	}
+	lockClienterMockGetPathsWithNoRetries.RLock()
+	calls = mock.calls.GetPathsWithNoRetries
+	lockClienterMockGetPathsWithNoRetries.RUnlock()
 	return calls
 }
 
@@ -449,6 +493,37 @@ func (mock *ClienterMock) SetMaxRetriesCalls() []struct {
 	lockClienterMockSetMaxRetries.RLock()
 	calls = mock.calls.SetMaxRetries
 	lockClienterMockSetMaxRetries.RUnlock()
+	return calls
+}
+
+// SetPathsWithNoRetries calls SetPathsWithNoRetriesFunc.
+func (mock *ClienterMock) SetPathsWithNoRetries(in1 []string) {
+	if mock.SetPathsWithNoRetriesFunc == nil {
+		panic("ClienterMock.SetPathsWithNoRetriesFunc: method is nil but Clienter.SetPathsWithNoRetries was just called")
+	}
+	callInfo := struct {
+		In1 []string
+	}{
+		In1: in1,
+	}
+	lockClienterMockSetPathsWithNoRetries.Lock()
+	mock.calls.SetPathsWithNoRetries = append(mock.calls.SetPathsWithNoRetries, callInfo)
+	lockClienterMockSetPathsWithNoRetries.Unlock()
+	mock.SetPathsWithNoRetriesFunc(in1)
+}
+
+// SetPathsWithNoRetriesCalls gets all the calls that were made to SetPathsWithNoRetries.
+// Check the length with:
+//     len(mockedClienter.SetPathsWithNoRetriesCalls())
+func (mock *ClienterMock) SetPathsWithNoRetriesCalls() []struct {
+	In1 []string
+} {
+	var calls []struct {
+		In1 []string
+	}
+	lockClienterMockSetPathsWithNoRetries.RLock()
+	calls = mock.calls.SetPathsWithNoRetries
+	lockClienterMockSetPathsWithNoRetries.RUnlock()
 	return calls
 }
 

--- a/mock_client.go
+++ b/mock_client.go
@@ -41,7 +41,7 @@ var (
 //             GetMaxRetriesFunc: func() int {
 // 	               panic("TODO: mock out the GetMaxRetries method")
 //             },
-//             GetPathsWithNoRetriesFunc: func() map[string]bool {
+//             GetPathsWithNoRetriesFunc: func() []string {
 // 	               panic("TODO: mock out the GetPathsWithNoRetries method")
 //             },
 //             HeadFunc: func(ctx context.Context, url string) (*http.Response, error) {
@@ -82,7 +82,7 @@ type ClienterMock struct {
 	GetMaxRetriesFunc func() int
 
 	// GetPathsWithNoRetriesFunc mocks the GetPathsWithNoRetries method.
-	GetPathsWithNoRetriesFunc func() map[string]bool
+	GetPathsWithNoRetriesFunc func() []string
 
 	// HeadFunc mocks the Head method.
 	HeadFunc func(ctx context.Context, url string) (*http.Response, error)
@@ -280,7 +280,7 @@ func (mock *ClienterMock) GetMaxRetriesCalls() []struct {
 }
 
 // GetPathsWithNoRetries calls GetPathsWithNoRetriesFunc.
-func (mock *ClienterMock) GetPathsWithNoRetries() map[string]bool {
+func (mock *ClienterMock) GetPathsWithNoRetries() []string {
 	if mock.GetPathsWithNoRetriesFunc == nil {
 		panic("ClienterMock.GetPathsWithNoRetriesFunc: method is nil but Clienter.GetPathsWithNoRetries was just called")
 	}

--- a/rchttptest/server.go
+++ b/rchttptest/server.go
@@ -31,6 +31,7 @@ type Responder struct {
 	Method    string              `json:"method"`
 	Error     string              `json:"error"`
 	Headers   map[string][]string `json:"headers"`
+	Path      string              `json:"path"`
 }
 
 type RequestTester struct {
@@ -60,6 +61,7 @@ func NewTestServer(statusCode int) *TestServer {
 			CallCount: ts.GetCalls(0),
 			Body:      string(b),
 			Headers:   headers,
+			Path:      r.URL.Path,
 		})
 		if err != nil {
 			convertErrorToOutput(w, contentType, err)


### PR DESCRIPTION
rchttp client contains a new variable PathsWithNoRetries to allow the thing setting up a new client to be able to handle no retries on certain paths (e.g. /health) while others maintain the default max retries count when hitting a 500 response.

Includes Getter and Setter methods to set this new variable.

* Check code logic
* Make sure unit tests pass on your local machine, you can run `make test`